### PR TITLE
Put the panic handler behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,7 @@ description = "A crate to write CMSIS-DAP flash algorithms for flashing embedded
 [dependencies]
 
 [features]
-default = ["erase-chip"]
+default = ["erase-chip", "panic-handler"]
 erase-chip = []
+panic-handler = []
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,18 @@
+//! Implement a [CMSIS-Pack] flash algorithm in Rust
+//! 
+//! [CMSIS-Pack]: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/flashAlgorithm.html
+//! 
+//! # Feature flags
+//! 
+//! - `panic-handler` this is enabled by default and includes a simple abort-on-panic
+//!   panic handler. Disable this feature flag if you would prefer to use a different
+//!   handler.
+
 #![no_std]
 #![no_main]
 #![macro_use]
 
-#[cfg(not(test))]
+#[cfg(all(not(test), feature = "panic-handler"))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe {


### PR DESCRIPTION
Shipping with a panic handler was messing my [docs with crates that had >1 binary](https://github.com/rust-lang/rust/issues/107918). Not sure why that issue exists and it's not this crate's fault, but I figured putting the handler behind a feature flag isn't a bad idea just in case somebody wants something specific.

I don't currently have hardware to test this with, so please verify this works as intended if you are able to.