### PR TITLE
Make EraseChip optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ repository = "https://github.com/probe-rs/flash-algorithm"
 description = "A crate to write CMSIS-DAP flash algorithms for flashing embedded targets."
 
 [dependencies]
+
+[features]
+default = ["erase-chip"]
+erase-chip = []


### PR DESCRIPTION
According to [this document](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/flashAlgorithm.html#FlashPrg), only `Init`, `UnInit`, `EraseSector`, and `ProgramPage` are mandatory.

> The file FlashPrg.c contains the mandatory Flash programming functions [Init](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/algorithmFunc.html#Init), [UnInit](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/algorithmFunc.html#UnInit), [EraseSector](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/algorithmFunc.html#EraseSector), and [ProgramPage](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/algorithmFunc.html#ProgramPage). Optionally, depending on the device features (or to speed-up execution), the functions [EraseChip](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/algorithmFunc.html#EraseChip), [BlankCheck](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/algorithmFunc.html#BlankCheck), and [Verify](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/algorithmFunc.html#Verify) can be implemented.

Leaving the optional functions opt-in allows support for `Verify` and `BlankCheck` to be added later without breaking compatibility.