### PR TITLE
Extend the API macro to accept all arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash-algorithm"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 readme = "README.md"
 keywords = ["no-std", "embedded", "flashing"]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,56 @@
+#![no_std]
+#![no_main]
+
+use flash_algorithm::FlashAlgorithm;
+
+struct Algorithm;
+
+flash_algorithm::algorithm!(Algorithm, {
+    device_name: "test",
+    device_type: DeviceType::Onchip,
+    flash_address: 0x0,
+    flash_size: 0x0,
+    page_size: 0x0,
+    empty_value: 0xFF,
+    program_time_out: 1000,
+    erase_time_out: 2000,
+    sectors: [{
+        size: 0x0,
+        address: 0x0,
+    }]
+});
+
+impl FlashAlgorithm for Algorithm {
+    fn new(
+        _address: u32,
+        _clock: u32,
+        _function: flash_algorithm::Function,
+    ) -> Result<Self, flash_algorithm::ErrorCode> {
+        todo!()
+    }
+
+    fn erase_all(&mut self) -> Result<(), flash_algorithm::ErrorCode> {
+        todo!()
+    }
+
+    fn erase_sector(&mut self, _address: u32) -> Result<(), flash_algorithm::ErrorCode> {
+        todo!()
+    }
+
+    fn program_page(
+        &mut self,
+        _address: u32,
+        _data: &[u8],
+    ) -> Result<(), flash_algorithm::ErrorCode> {
+        todo!()
+    }
+
+    fn verify(
+        &mut self,
+        _address: u32,
+        _size: u32,
+        _data: Option<&[u8]>,
+    ) -> Result<(), flash_algorithm::ErrorCode> {
+        todo!()
+    }
+}


### PR DESCRIPTION
I fixed most points. I am not sure how to fix:

- `In memory.x, the data, sdata, and bss sections are duplicated and should be removed from PrgCode.` Maybe @Tiwalun knows. I feel like all might be needed?
- `There is one quirky bit in the scripts that expect the PrgData to be marked RW, so I needed to a dummy global variable. I don't know if there is another way to force the section to be read-write.` I am not sure it has to be marked RW? Never had issues with any of the algos and we don't check that. Also, I would rather forego the dummy.

cc @mbossard, @Tiwalun  