### PR TITLE
add missing ReadFlash(optional) function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash-algorithm"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 readme = "README.md"
 keywords = ["no-std", "embedded", "flashing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ description = "A crate to write CMSIS-DAP flash algorithms for flashing embedded
 default = ["erase-chip", "panic-handler"]
 erase-chip = []
 panic-handler = []
+read-flash = []
 verify = []


### PR DESCRIPTION
The option pc_read was added in the following PR https://github.com/probe-rs/probe-rs/pull/2727, but it wasn't added in the flash-algorithm repo. So, this PR simply adds missing ReadFlash function.